### PR TITLE
加快秒杀轮询效率

### DIFF
--- a/hpv4g.py
+++ b/hpv4g.py
@@ -34,7 +34,7 @@ def sec_kill_task(miao_miao, req_param, proxy=None):
     :return:
     """
     #在进入秒杀轮询前计算好ECC-HS值，降低轮询执行时间
-    miaomiao._headers['ecc-hs'] = MiaoMiao._ecc_hs_header(req_param["seckillId"], req_param["linkmanId"])
+    miao_miao._headers['ecc-hs'] = MiaoMiao._ecc_hs_header(req_param["seckillId"], req_param["linkmanId"])
     _start_time = req_param['startTimeUnx']
     # 距秒杀开始300ms 开始执行请求
     while _start_time - int(datetime.datetime.now().timestamp() * 1000) > 300:

--- a/hpv4g.py
+++ b/hpv4g.py
@@ -33,6 +33,8 @@ def sec_kill_task(miao_miao, req_param, proxy=None):
     执行秒杀操作
     :return:
     """
+    #在进入秒杀轮询前计算好ECC-HS值，降低轮询执行时间
+    miaomiao._headers['ecc-hs'] = MiaoMiao._ecc_hs_header(req_param["seckillId"], req_param["linkmanId"])
     _start_time = req_param['startTimeUnx']
     # 距秒杀开始300ms 开始执行请求
     while _start_time - int(datetime.datetime.now().timestamp() * 1000) > 300:

--- a/miaomiao.py
+++ b/miaomiao.py
@@ -187,7 +187,6 @@ class MiaoMiao():
         :return:
         """
         # error_exit=False 忽略Server端使用5XX防爬策略
-        self._headers['ecc-hs'] = MiaoMiao._ecc_hs_header(req_param["seckillId"], req_param["linkmanId"])
         return MiaoMiao._get(URLS['SEC_KILL'], params=req_param, error_exit=False, headers=self._headers,
                              proxies=proxies, verify=False)
 


### PR DESCRIPTION
将计算ECC_HS的操作从秒杀轮询移出，在初始化中完成md5计算，能够加快秒杀轮询效率。